### PR TITLE
Split into lib/index.js, lib/partial-collector.js

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,151 @@
+/*
+ * Original work Copyright (c) 2016 Benjamin Legrand under the MIT License
+ * https://github.com/benjilegnard/rollup-plugin-handlebars
+ *
+ * Original work Copyright (c) 2016 Mixmax, Inc under the MIT License
+ * https://github.com/mixmaxhq/rollup-plugin-handlebars-plus
+ *
+ * Derived work Copyright (c) 2023 Mike Bland <mbland@acm.org> under the
+ * Mozilla Public License Version 2.0
+ * https://github.com/mbland/rollup-plugin-handlebars-precompiler
+ *
+ * MIT License
+ * -----------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Mozilla Public License Version 2.0
+ * ----------------------------------
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import PartialCollector from './partial-collector.js'
+import { createFilter } from '@rollup/pluginutils'
+import Handlebars from 'handlebars'
+
+export const PLUGIN_NAME = 'handlebars-precompiler'
+const DEFAULT_INCLUDE = ['**/*.hbs', '**/*.handlebars', '**/*.mustache']
+const DEFAULT_EXCLUDE = 'node_modules/**'
+const DEFAULT_PARTIALS = '**/_*'
+const DEFAULT_PARTIAL_NAME = id => {
+  return id.replace(/.*\//, '')    // extract the basename
+    .replace(/\.[^.]*$/, '')       // remove the file extension, if present
+    .replace(/^[^[:alnum:]]*/, '') // strip leading non-alphanumeric characters
+}
+const DEFAULT_PARTIAL_PATH = (partialName, importerPath) => {
+  return `./_${partialName}.${importerPath.replace(/.*\./, '')}`
+}
+
+const PLUGIN_ID = `\0${PLUGIN_NAME}`
+const HANDLEBARS_PATH = 'handlebars/lib/handlebars.runtime'
+const IMPORT_HANDLEBARS = `import Handlebars from '${HANDLEBARS_PATH}'`
+const IMPORT_HELPERS = `import Render from '${PLUGIN_ID}'`
+
+/**
+ * Rollup Handlebars precompiler implementation
+ */
+export default class PluginImpl {
+  #helpers
+  #isTemplate
+  #isPartial
+  #partialName
+  #partialPath
+  #compilerOpts
+  #adjustSourceMap
+
+  constructor(options = {}) {
+    this.#helpers = options.helpers || []
+    this.#isTemplate = createFilter(
+      options.include || DEFAULT_INCLUDE,
+      options.exclude || DEFAULT_EXCLUDE
+    )
+    this.#isPartial = createFilter(options.partials || DEFAULT_PARTIALS)
+    this.#partialName = options.partialName || DEFAULT_PARTIAL_NAME
+    this.#partialPath = options.partialPath || DEFAULT_PARTIAL_PATH
+
+    const compilerOpts = { ...options.compiler }
+    delete compilerOpts.srcName
+    delete compilerOpts.destName
+    this.#compilerOpts = (id) => ({ srcName: id, ...compilerOpts })
+    this.#adjustSourceMap = function adjustSourceMap(map, numLinesBeforeTmpl) {
+      const parsed = JSON.parse(map)
+      parsed.mappings = `${';'.repeat(numLinesBeforeTmpl)}${parsed.mappings}`
+      return parsed
+    }
+
+    // This specifies that source maps can be disabled via "sourceMap: false":
+    // - https://rollupjs.org/plugin-development/#source-code-transformations
+    //
+    // This specifies that source maps can be disabled via "sourcemap: false":
+    // - https://rollupjs.org/troubleshooting/#warning-sourcemap-is-likely-to-be-incorrect
+    if (options.sourceMap === false || options.sourcemap === false) {
+      this.#compilerOpts = () => compilerOpts
+      this.#adjustSourceMap = () => ({ mappings: '' })
+    }
+  }
+
+  shouldEmitHelpersModule(id) { return id === PLUGIN_ID }
+
+  helpersModule() {
+    const helpers = this.#helpers
+    return [
+      IMPORT_HANDLEBARS,
+      ...helpers.map((h, i) => `import registerHelpers${i} from './${h}'`),
+      ...helpers.map((_, i) => `registerHelpers${i}(Handlebars)`),
+      // Inspired by: https://stackoverflow.com/a/35385518
+      'export default (rawTemplate) => ((context, options) => {',
+      '  const t = document.createElement(\'template\')',
+      '  t.innerHTML = rawTemplate(context, options)',
+      '  return t.content',
+      '})'
+    ].join('\n')
+  }
+
+  isTemplate(id) { return this.#isTemplate(id) }
+
+  compile(code, id) {
+    const opts = this.#compilerOpts(id)
+    const ast = Handlebars.parse(code, opts)
+    const compiled = Handlebars.precompile(ast, opts)
+    const { code: tmpl = compiled, map: srcMap } = compiled
+    const collector = new PartialCollector()
+    collector.accept(ast)
+
+    const beforeTmpl = [
+      IMPORT_HANDLEBARS,
+      IMPORT_HELPERS,
+      ...collector.partials.map(p => `import '${this.#partialPath(p, id)}'`),
+      'export const RawTemplate = Handlebars.template('
+    ]
+    const afterTmpl = [
+      ')',
+      'export default Render(RawTemplate)',
+      ...(this.#isPartial(id) ? [ this.#partialRegistration(id) ] : [])
+    ]
+    return {
+      code: [ ...beforeTmpl, tmpl, ...afterTmpl ].join('\n'),
+      map: this.#adjustSourceMap(srcMap, beforeTmpl.length)
+    }
+  }
+
+  #partialRegistration(id) {
+    return `Handlebars.registerPartial('${this.#partialName(id)}', RawTemplate)`
+  }
+}

--- a/lib/partial-collector.js
+++ b/lib/partial-collector.js
@@ -36,25 +36,24 @@
  * obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import PluginImpl, { PLUGIN_NAME } from './lib/index.js'
+import Handlebars from 'handlebars'
 
 /**
- * A Rollup plugin object for precompiling Handlebars templates.
- * @module rollup-plugin-handlebars-precompiler
+ * Collects the names of partial templates from a Handlebars template
+ * @see https://github.com/handlebars-lang/handlebars.js/blob/master/docs/compiler-api.md
  */
+export default class PartialCollector extends Handlebars.Visitor {
+  partials = []
 
-/**
- * Returns a Rollup plugin object for precompiling Handlebars templates.
- * @function default
- * @param {object} options object containing Handlebars compiler API options
- * @returns {object} a Rollup plugin that precompiles Handlebars templates
- */
-export default function HandlebarsPrecompiler(options) {
-  const p = new PluginImpl(options)
-  return {
-    name: PLUGIN_NAME,
-    resolveId(id) { if (p.shouldEmitHelpersModule(id)) return id },
-    load(id) { if (p.shouldEmitHelpersModule(id)) return p.helpersModule() },
-    transform(code, id) { if (p.isTemplate(id)) return p.compile(code, id) }
+  PartialStatement(partial) {
+    this.collect(partial.name)
+    return super.PartialStatement(partial)
   }
+
+  PartialBlockStatement(partial) {
+    this.collect(partial.name)
+    return super.PartialBlockStatement(partial)
+  }
+
+  collect(n) { if (n.type === 'PathExpression') this.partials.push(n.original) }
 }

--- a/package.json
+++ b/package.json
@@ -9,9 +9,7 @@
     "test:ci": "eslint --color --max-warnings 0 . && vitest run -c ci/vitest.config.js",
     "jsdoc": "jsdoc-cli-wrapper -c jsdoc.json ."
   },
-  "files": [
-    "index.js"
-  ],
+  "files": [ "index.js", "lib/*" ],
   "keywords": [
     "rollup",
     "handlebars",

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -5,21 +5,18 @@
  */
 
 import { describe, expect, test } from 'vitest'
-import HandlebarsPrecompiler, * as Plugin from '../index.js'
+import HandlebarsPrecompiler from '../index.js'
+import { PLUGIN_NAME } from '../lib/index.js'
 
-const { PLUGIN_NAME, PLUGIN_ID } = Plugin
+const PLUGIN_ID = `\0${PLUGIN_NAME}`
 
 describe('HandlebarsPrecompiler', () => {
   const plugin = HandlebarsPrecompiler({
     helpers: ['foo.js']
   })
 
-  test(`.name is ${Plugin.PLUGIN_NAME}`, () => {
+  test(`.name is ${PLUGIN_NAME}`, () => {
     expect(plugin.name).toBe(PLUGIN_NAME)
-  })
-
-  test('PLUGIN_ID starts with null byte', () => {
-    expect(PLUGIN_ID[0]).toBe('\0')
   })
 
   describe('resolveId', () => {


### PR DESCRIPTION
This preserves all existing behavior, but will make writing tests cleaner and easier.