### PR TITLE
Final PluginImpl.compile() tests, custom matchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 _**Status**: I've still got a bit of work to do before publishing v1.0.0. I need
 to add tests based on the mbland/tomcat-servlet-testing-example project from
-whence this came, add more documentation, and refactor. I plan to finish this by
-2024-01-06._
+whence this came and add more documentation. I plan to finish this by
+2024-01-08._
 
 Source: <https://github.com/mbland/rollup-plugin-handlebars-precompiler>
 


### PR DESCRIPTION
PluginImpl.compile() is now 100% covered, as is the whole package, with these tests for partial imports, partial registration, and related options.

Added custom Vitest expect matchers, toStartWith and toEndWith. I may want to package these at some point, though I'm not sure.

- https://vitest.dev/guide/extending-matchers.html

---

Though the code's 100% covered by small-to-medium tests, I do want to add an integration test to ensure the generated code loads correctly. (test/main.test.js is the medium-ish test.) I've effectively done that already in the strcalc/src/main/frontend tests from mbland/tomcat-servlet-testing-example. I just need to port some of the work I did there over here.